### PR TITLE
Add book viewer section with page-turning reader

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,8 @@
 
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/turn.js/4.1.0/turn.min.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600;700&family=Lato:wght@300;400&display=swap" rel="stylesheet">
@@ -71,6 +73,23 @@
             height: 400px;
             max-height: 50vh;
         }
+        #book-viewer {
+            width: 100%;
+            max-width: 800px;
+            height: 600px;
+            margin-left: auto;
+            margin-right: auto;
+            background-color: #FFFFFF;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+        }
+        #book-viewer .page {
+            background-color: #FFFFFF;
+        }
+        @media (max-width: 768px) {
+            #book-viewer {
+                height: 400px;
+            }
+        }
     </style>
 </head>
 <body class="antialiased">
@@ -88,6 +107,7 @@
                         <a href="#places" class="nav-link px-3 py-2 rounded-md text-sm font-medium">Places</a>
                         <a href="#timeline" class="nav-link px-3 py-2 rounded-md text-sm font-medium">Timeline</a>
                         <a href="#themes" class="nav-link px-3 py-2 rounded-md text-sm font-medium">Themes</a>
+                        <a href="#book" class="nav-link px-3 py-2 rounded-md text-sm font-medium">Book</a>
                     </div>
                 </div>
             </div>
@@ -213,6 +233,12 @@
                 </div>
             </div>
         </section>
+
+        <section id="book" class="py-20 bg-[#FDF8F2]">
+            <div class="max-w-4xl mx-auto px-4">
+                <div id="book-viewer" class="h-[600px]"></div>
+            </div>
+        </section>
     </main>
 
     <footer class="bg-[#4A4A4A] text-white py-8">
@@ -283,6 +309,27 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const characterDisplay = document.getElementById('character-display');
     const timelineContainer = document.getElementById('timeline-container');
+    const bookViewer = document.getElementById('book-viewer');
+
+    if (bookViewer) {
+        fetch('public/book/avant-le-diamant.pdf')
+            .then(res => res.blob())
+            .then(blob => {
+                const url = URL.createObjectURL(blob);
+                const page1 = document.createElement('div');
+                page1.className = 'page';
+                page1.innerHTML = `<object data="${url}" type="application/pdf" width="100%" height="100%"></object>`;
+                const page2 = document.createElement('div');
+                page2.className = 'page';
+                bookViewer.appendChild(page1);
+                bookViewer.appendChild(page2);
+                $(bookViewer).turn({
+                    width: 800,
+                    height: 600,
+                    autoCenter: true
+                });
+            });
+    }
 
     window.selectCharacter = (charKey) => {
         const characters = document.querySelectorAll('.character-portrait');

--- a/public/book/avant-le-diamant.pdf
+++ b/public/book/avant-le-diamant.pdf
@@ -1,0 +1,32 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 47 >>
+stream
+BT /F1 24 Tf 72 720 Td (Avant le Diamant) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000338 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+408
+%%EOF


### PR DESCRIPTION
## Summary
- load jQuery and Turn.js to enable a page-flipping book viewer
- add Book navigation link and section with styled viewer container
- initialize viewer and include placeholder PDF content

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896707563ec833199217d7e0fd802af