### PR TITLE
Ensure PDF objects fill book viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,6 +85,11 @@
         #book-viewer .page {
             background-color: #FFFFFF;
         }
+        #book-viewer .page object {
+            display: block;
+            width: 100%;
+            height: 100%;
+        }
         @media (max-width: 768px) {
             #book-viewer {
                 height: 400px;


### PR DESCRIPTION
## Summary
- Add CSS rule for `#book-viewer .page object` so embedded PDFs expand to the full viewer dimensions.

## Testing
- `npx --yes -p playwright@1.42.0 node <script>` *(fails: npm 403 Forbidden - GET https://registry.npmjs.org/playwright)*


------
https://chatgpt.com/codex/tasks/task_e_68967a31087c8331a15cb7edacd3965f