### PR TITLE
Add mobile PDF fallback using PDF.js viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/turn.js/4.1.0/turn.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/pdfjs-dist@3.9.179/build/pdf.min.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;600;700&family=Lato:wght@300;400&display=swap" rel="stylesheet">
@@ -82,6 +83,19 @@
             background-color: #FFFFFF;
             box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
         }
+        #book-fallback {
+            width: 100%;
+            max-width: 800px;
+            margin-left: auto;
+            margin-right: auto;
+        }
+        #pdf-render canvas {
+            width: 100%;
+            height: auto;
+            display: block;
+            margin-bottom: 1rem;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+        }
         #book-viewer .page {
             background-color: #FFFFFF;
         }
@@ -93,6 +107,9 @@
         @media (max-width: 768px) {
             #book-viewer {
                 height: 400px;
+            }
+            #pdf-render canvas {
+                max-height: 400px;
             }
         }
     </style>
@@ -246,6 +263,10 @@
                     <a href="public/book/avant-le-diamant.pdf" download class="mt-4 inline-block text-lg font-serif text-[#9A1717] hover:underline">Download the book</a>
                 </div>
                 <div id="book-viewer" class="h-[600px]"></div>
+                <div id="book-fallback" class="hidden text-center mt-4">
+                    <p class="text-gray-700">PDF viewing is not supported on your device. <a href="public/book/avant-le-diamant.pdf" class="text-[#9A1717] underline">Download the book</a> instead.</p>
+                    <div id="pdf-render" class="mt-4"></div>
+                </div>
             </div>
         </section>
     </main>
@@ -319,25 +340,59 @@ document.addEventListener('DOMContentLoaded', () => {
     const characterDisplay = document.getElementById('character-display');
     const timelineContainer = document.getElementById('timeline-container');
     const bookViewer = document.getElementById('book-viewer');
+    const bookFallback = document.getElementById('book-fallback');
+    const pdfRender = document.getElementById('pdf-render');
+
+    function isMobile() {
+        return /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+    }
+
+    function supportsPdfEmbedding() {
+        return typeof navigator.mimeTypes['application/pdf'] !== 'undefined' && !isMobile();
+    }
 
     if (bookViewer) {
-        fetch('public/book/avant-le-diamant.pdf')
-            .then(res => res.blob())
-            .then(blob => {
-                const url = URL.createObjectURL(blob);
-                const page1 = document.createElement('div');
-                page1.className = 'page';
-                page1.innerHTML = `<object data="${url}" type="application/pdf" width="100%" height="100%"></object>`;
-                const page2 = document.createElement('div');
-                page2.className = 'page';
-                bookViewer.appendChild(page1);
-                bookViewer.appendChild(page2);
-                $(bookViewer).turn({
-                    width: 800,
-                    height: 600,
-                    autoCenter: true
+        if (supportsPdfEmbedding()) {
+            fetch('public/book/avant-le-diamant.pdf')
+                .then(res => res.blob())
+                .then(blob => {
+                    const url = URL.createObjectURL(blob);
+                    const page1 = document.createElement('div');
+                    page1.className = 'page';
+                    page1.innerHTML = `<object data="${url}" type="application/pdf" width="100%" height="100%"></object>`;
+                    const page2 = document.createElement('div');
+                    page2.className = 'page';
+                    bookViewer.appendChild(page1);
+                    bookViewer.appendChild(page2);
+                    $(bookViewer).turn({
+                        width: 800,
+                        height: 600,
+                        autoCenter: true
+                    });
                 });
-            });
+        } else {
+            bookViewer.classList.add('hidden');
+            if (bookFallback) {
+                bookFallback.classList.remove('hidden');
+                if (window.pdfjsLib && pdfRender) {
+                    pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdn.jsdelivr.net/npm/pdfjs-dist@3.9.179/build/pdf.worker.min.js';
+                    pdfjsLib.getDocument('public/book/avant-le-diamant.pdf').promise.then(pdf => {
+                        for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
+                            pdf.getPage(pageNum).then(page => {
+                                const viewport = page.getViewport({ scale: 1.5 });
+                                const canvas = document.createElement('canvas');
+                                canvas.className = 'mb-4 mx-auto';
+                                const context = canvas.getContext('2d');
+                                canvas.width = viewport.width;
+                                canvas.height = viewport.height;
+                                pdfRender.appendChild(canvas);
+                                page.render({ canvasContext: context, viewport });
+                            });
+                        }
+                    });
+                }
+            }
+        }
     }
 
     window.selectCharacter = (charKey) => {


### PR DESCRIPTION
## Summary
- load PDF.js to render the book when native PDF embedding is unavailable on mobile devices
- hide the book viewer on unsupported browsers and render pages via PDF.js with a responsive fallback layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68967b581e3083318877755339321aa5